### PR TITLE
Fix/purged styles

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,23 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-size: 20px;
+}
+
+/* Print styles */
+@media print {
+  [data-appear='false'],
+  .invisible {
+    visibility: visible;
+  }
+  .slide {
+    opacity: 1;
+    position: static;
+    transform: none;
+  }
+  .deck {
+    overflow: visible;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,30 +1,7 @@
 <html>
   <head>
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-    <style>
-      :root {
-        font-size: 20px;
-      }
-      @tailwind base;
-      @tailwind components;
-      @tailwind utilities;
-    </style>
-    <style>
-      /* Print styles */
-      @media print {
-        [data-appear="false"], .invisible {
-          visibility: visible;
-        }
-        .slide {
-          opacity: 1;
-          position: static;
-          transform: none;
-        }
-        .deck {
-          overflow: visible;
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="./index.css"> 
   </head>
   <body>
     <main id="minideck"></main>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,12 @@ module.exports = {
   theme: {
     extend: {},
   },
-  purge: ["./index.html", "./index.js", "./components/**/*.js"],
+  purge: [
+    './index.html',
+    './index.js',
+    './components/**/*.js',
+    './content.mdx',
+  ],
   variants: {},
   plugins: [],
 };


### PR DESCRIPTION
Resolves #19. It turns out that the solution was only to add the .mdx file into the purge options for Tailwind to use to identify classNames. But moving the styles out into an external file seemed good too.